### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
-[![Downloads](https://pypip.in/d/SPADE/badge.png)](https://pypi.python.org/pypi/SPADE)
-[![Version](https://pypip.in/v/SPADE/badge.png)](https://pypi.python.org/pypi/SPADE)
+[![Downloads](https://img.shields.io/pypi/dm/SPADE.svg)](https://pypi.python.org/pypi/SPADE)
+[![Version](https://img.shields.io/pypi/v/SPADE.svg)](https://pypi.python.org/pypi/SPADE)
 [![Build Status](https://travis-ci.org/javipalanca/spade.png)](https://travis-ci.org/javipalanca/spade)
 
 SPADE (Smart Python multi-Agent Development Environment) is a Multiagent and Organizations Platform based on the <a href="http://www.xmpp.org">XMPP/Jabber technology</a> and written in the <a href="http://www.python.org">Python</a> programming language. This technology offers by itself many features and facilities that ease the construction of MAS, such as an existing communication channel, the concepts of users (agents) and servers (platforms) and an extensible communication protocol based on XML, just like <a href="http://www.fipa.org">FIPA-ACL</a>. Many other agent platforms exist, but SPADE is the first to base its roots on the XMPP technology.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20spade))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `spade`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.