### PR TITLE
Corrected output of dummy agent example given in usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -191,7 +191,6 @@ And the output of this example would be::
     Counter: 0
     Counter: 1
     Counter: 2
-    Counter: 3
     Behaviour finished with exit code 10.
 
 


### PR DESCRIPTION
Corrected the output of an example code given for dummy agent where output should only print value of counter upto 2 only.