### PR TITLE
Added waiting for fsmagent to start

### DIFF
--- a/docs/behaviours.rst
+++ b/docs/behaviours.rst
@@ -292,7 +292,8 @@ transit to::
 
     if __name__ == "__main__":
         fsmagent = FSMAgent("fsmagent@your_xmpp_server", "your_password")
-        fsmagent.start()
+        future = fsmagent.start()
+        future.result() 
 
         while fsmagent.is_alive():
             try:


### PR DESCRIPTION
It is necessary to wait for the agent to start otherwise the program instantly finishes. 
Hence, I corrected the documentation about finite state machine agents.

Please consider merging this PR to improve the docs. 