### PR TITLE
Fix usage.rst type

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -232,7 +232,7 @@ Creating an agent from within another agent
 -------------------------------------------
 
 There is a common use case where you may need to create an agent from within another agent, that is, from within another
-agent's behaviour. This is a common case where ```start`` must be called with an ``await`` statement in order to work properly. Example::
+agent's behaviour. This is a common case where ``start`` must be called with an ``await`` statement in order to work properly. Example::
 
     import spade
     from spade.agent import Agent


### PR DESCRIPTION
Remove a redundant ` from the text (was triple `, should be double `).