### PR TITLE
Clarify approve_all flag location

### DIFF
--- a/docs/presence.rst
+++ b/docs/presence.rst
@@ -174,7 +174,7 @@ There are four handlers that you can override to manage these kind of messages: 
 
 .. note:: In the previous example you can see also how to approve a subscription request by using the ``approve`` method.
 
-.. tip:: If you want to automatically approve all subscription requests you can set the ``approve_all`` flag to ``True``.
+.. tip:: If you want to automatically approve all subscription requests you can set the ``PresenceManager.approve_all`` flag to ``True``.
 
 
 Example


### PR DESCRIPTION
Specify what class the `approve_all` flag belongs to.


For me personally, it was not directly clear what class the flag belonged to and I had to inspect the source code. I propose this change to make this more clear in the docs.