### PR TITLE
Added missing xep

### DIFF
--- a/spade/xmpp_client.py
+++ b/spade/xmpp_client.py
@@ -28,6 +28,9 @@ class XMPPClient(ClientXMPP):
             self.add_event_handler("register", self.register)
             self.register_plugin('xep_0077')  # In-band-registration
 
+        self.register_plugin('xep_0199')  # Ping / Keepalive connection
+        self['xep_0199'].enable_keepalive(interval=55)
+
     def session_start(self, event):
         self.send_presence()
         self.get_roster()


### PR DESCRIPTION
The migration for the new XMPP library misses the ping XEP, needed for keeping alive the connection with the server.

[https://slixmpp.readthedocs.io/en/latest/api/plugins/xep_0199.html](url)