### PR TITLE
Pin dependencies: slixmpp <=1.9.1, pyjabber <=0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slixmpp>=1.8.5
+slixmpp>=1.8.5,<=1.9.1
 aiohttp>=3.10.4
 aiohttp_jinja2==1.6
 jinja2==3.0.3
@@ -6,7 +6,7 @@ jinja2-time==0.2.0
 timeago==1.0.16
 singletonify==0.2.4
 pytz==2022.1
-pyjabber>=0.1.9
+pyjabber>=0.1.9,<=0.2.4
 rich>=13.9.4
 uvloop>=0.21.0; platform_system != "Windows"
 winloop>=0.1.7; platform_system == "Windows"


### PR DESCRIPTION
Added upper bounds to slixmpp (<=1.9.1) and pyjabber (<=0.2.4) to revert compatibility issues and ensures consistent behavior and avoids breaking changes in upstream libraries.