### PR TITLE
e2e with parallel server

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,13 +2,45 @@
 Quick Start
 ===========
 
-Creating your first dummy agent
+Preparing the environment
 -------------------------------
+Before you start using the SPADE platform, you need to set up the execution environment.
+The platform is based on the XMPP communication protocol and requires a dedicated server to function properly.
+At this point, you can choose between three scenarios:
 
-It's time for us to build our first SPADE agent. SPADE includes its own XMPP server, 
-which can be launched with the command ``spade run``. Agents are automatically registered on this server. 
-However, if desired, an external server can also be used.
-In this example, we will assume that our jid is *your_jid@localhost* and the password is *your_password*.
+SPADE coroutine executor
+########################
+A SPADE agent is asynchronous, meaning that all the code required to run an agent must be executed within an asynchronous loop.
+This is achieved using the *spade.run()* function. This function takes a coroutine as its first parameter and runs it within an
+asynchronous loop. The second parameter is a boolean (default is False). If set to True, an internal server instance will be
+launched, managed during the coroutine's lifespan, and deleted once it finishes.
+
+.. code-block:: python
+
+    async def main():
+            dummy = DummyAgent("dummy@localhost", "your_password")
+            await dummy.start()
+
+        if __name__ == "__main__":
+            spade.run(main(), True)
+                        ^       ^
+                        |       |
+                    coroutine   |
+                                |
+                            Server Flag
+This is the preferred method for launching SPADE scripts, as it eliminates the need for the user to install or manage any external server.
+
+
+.. note:: The launched server will use *localhost* as its host. Keep this in mind when creating agents and assigning their JIDs.
+    A valid JID would be something like *agent1@localhost* or *agent1@127.0.0.1*
+
+
+
+SPADE CLI command
+#####################
+The same server described previously can be launched independently from any agent using *spade run*.
+This approach is useful for more complex MAS integrations and for obtaining a detailed log of the messages exchanged between agents.
+
 
 .. code-block:: bash
 
@@ -32,15 +64,32 @@ In this example, we will assume that our jid is *your_jid@localhost* and the pas
     yyyy-m-d h:m:s | INFO     | pyjabber.server:run_server:150 - Server started...
     yyyy-m-d h:m:s | INFO     | pyjabber.webpage.adminPage:start:35 - Serving admin webpage on http://localhost:9090
 
+.. note:: The launched server will use *localhost* as its host. Keep this in mind when creating agents and assigning their JIDs.
+    A valid JID would be something like *agent1@localhost* or *agent1@127.0.0.1*
 
-.. warning:: The SPADE server **MUST** be running in order to run the agents. If you close the server, the agents will stop working. 
+Dedicated XMPP server
+####################
+Any XMPP server can be used with the SPADE platform. *Prosody* is a well-tested solution with SPADE,
+but there is a wide range of popular servers with large communities.
+
+.. warning:: Make sure that *spade.run()* does not launch the internal server if your dedicated server
+    is already running, as this can cause conflicts with the port binding.
+
+
+Creating your first dummy agent
+-------------------------------
+
+It's time for us to build our first SPADE agent.
+
+
+.. warning:: The SPADE server **MUST** be running in order to run the agents. If you close the server, the agents will stop working.
 
 .. hint:: To install a different XMPP server visit https://xmpp.org/software/servers.html (we recommend `Prosody IM <https://prosody.im>`_)
 
 .. hint:: To create a new XMPP account you can follow the steps of https://xmpp.org/getting-started/
 
 
-A basic SPADE agent is really a Python script that imports the spade module and that 
+A basic SPADE agent is really a Python script that imports the spade module and that
 uses the constructs defined therein. For starters, fire up your favorite Python editor and create a file called ``dummyagent.py``.
 
 
@@ -291,7 +340,6 @@ agent's behaviour. This is a common case where ``start`` must be called with an 
 
     if __name__ == "__main__":
         spade.run(main())
-
 
 
 

--- a/spade/presence.py
+++ b/spade/presence.py
@@ -132,11 +132,15 @@ class PresenceManager:
         self.current_presence: Optional[PresenceInfo] = None
         self.approve_all = approve_all
         # Adding event handlers to handle incoming presence and subscription events
-        self.agent.client.add_event_handler("presence_available", self.handle_presence)
+        self.agent.client.add_event_handler(
+            "presence_available", self.handle_presence
+        )
         self.agent.client.add_event_handler(
             "presence_unavailable", self.handle_presence
         )
-        self.agent.client.add_event_handler("changed_status", self.handle_presence)
+        self.agent.client.add_event_handler(
+            "changed_status", self.handle_presence
+        )
         self.agent.client.add_event_handler(
             "presence_subscribe", self.handle_subscription
         )
@@ -192,7 +196,7 @@ class PresenceManager:
         if bare_jid not in self.contacts:
             # Create a new contact if it doesn't exist
             self.contacts[bare_jid] = Contact(
-                jid=JID(peer_jid), name=name, subscription="", ask="", groups=[]
+                jid=JID(peer_jid), name=name, subscription="none", ask="", groups=[]
             )
         # Update the presence of the contact
         self.contacts[bare_jid].update_presence(resource, presence_info)
@@ -206,6 +210,8 @@ class PresenceManager:
                 peer_jid, presence_info, self.contacts[bare_jid].last_presence
             )
 
+        self.on_presence_received(presence)
+
     def handle_subscription(self, presence: Presence):
         peer_jid = presence["from"].bare
         subscription_type = presence["type"]
@@ -216,13 +222,10 @@ class PresenceManager:
             self.contacts[peer_jid] = Contact(
                 jid=JID(peer_jid),
                 name=peer_jid,
-                subscription=subscription_type,
+                subscription="none",
                 ask=ask,
                 groups=[],
             )
-        else:
-            # Update the subscription information
-            self.contacts[peer_jid].update_subscription(subscription_type, ask)
 
         # Call user-defined handler or automatically approve if approve_all is True
         if subscription_type == "subscribe" and self.approve_all:
@@ -231,10 +234,12 @@ class PresenceManager:
         elif subscription_type == "subscribe":
             self.on_subscribe(peer_jid)
         elif subscription_type == "subscribed":
+            self.subscribed(peer_jid)
             self.on_subscribed(peer_jid)
         elif subscription_type == "unsubscribe":
             self.on_unsubscribe(peer_jid)
         elif subscription_type == "unsubscribed":
+            self.unsubscribed(peer_jid)
             self.on_unsubscribed(peer_jid)
 
     def handle_roster_update(self, event):
@@ -320,21 +325,54 @@ class PresenceManager:
                 jid=JID(jid), name=jid, subscription="to", ask="subscribe", groups=[]
             )
         else:
-            self.contacts[jid].update_subscription("to", "subscribe")
+            if self.contacts[jid].subscription == "from":
+                self.contacts[jid].update_subscription("from", "subscribe")
+            else:
+                self.contacts[jid].update_subscription("to", "subscribe")
         # Send the subscription stanza to the server
         self.agent.client.send_presence(pto=jid, ptype="subscribe")
+
+    def subscribed(self, jid: str):
+        # Logic to update contact subscription with subscribe
+        if jid not in self.contacts:
+            self.contacts[jid] = Contact(
+                jid=JID(jid), name=jid, subscription="to", ask="", groups=[]
+            )
+        else:
+            if self.contacts[jid].subscription == "none" and self.contacts[jid].ask == "subscribe":
+                self.contacts[jid].update_subscription("to", "")
+            elif self.contacts[jid].subscription == "from" and self.contacts[jid].ask == "subscribe":
+                self.contacts[jid].update_subscription("both", "")
 
     def unsubscribe(self, jid: str):
         # Logic to send an unsubscription request to a contact
         if jid in self.contacts:
-            self.contacts[jid].update_subscription("unsubscribe", "unsubscribe")
+            if self.contacts[jid].subscription == "both":
+                self.contacts[jid].update_subscription("from", "")
+            elif self.contacts[jid].subscription == "to":
+                self.contacts[jid].update_subscription("none", "")
         # Send the unsubscription stanza to the server
         self.agent.client.send_presence(pto=jid, ptype="unsubscribe")
+
+    def unsubscribed(self, jid: str):
+        # Logic to update contact subscription with unsubscribe
+        if jid not in self.contacts:
+            self.contacts[jid] = Contact(
+                jid=JID(jid), name=jid, subscription="none", ask="", groups=[]
+            )
+        else:
+            if self.contacts[jid].subscription == "both":
+                self.contacts[jid].update_subscription("to", "")
+            elif self.contacts[jid].subscription == "from":
+                self.contacts[jid].update_subscription("none", "")
 
     def approve_subscription(self, jid: str):
         # Logic to approve a subscription request
         if jid in self.contacts:
-            self.contacts[jid].update_subscription("subscribed", "")
+            if self.contacts[jid].subscription == "to":
+                self.contacts[jid].update_subscription("both", "")
+            else:
+                self.contacts[jid].update_subscription("from", "")
         # Send the subscribed stanza to the server
         self.agent.client.send_presence(pto=jid, ptype="subscribed")
 
@@ -349,6 +387,9 @@ class PresenceManager:
         pass
 
     def on_unsubscribed(self, peer_jid: str):
+        pass
+
+    def on_presence_received(self, presence: Presence):
         pass
 
     def on_available(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import asyncio
 
 import pytest
+import pytest_asyncio
 from slixmpp import JID, Iq
 
 from spade.message import Message
-
+from pyjabber.server import Server
 
 pytest_plugins = "pytest_asyncio"
 
@@ -63,6 +64,20 @@ def iq():
 @pytest.fixture(scope="module", autouse=True)
 def cleanup(request):
     pass
+
+
+@pytest_asyncio.fixture(scope="function", autouse=False)
+async def server(event_loop):
+    server = Server()
+    server_task = event_loop.create_task(server.start())
+    await server.ready.wait()
+    yield event_loop
+    server_task.cancel()
+    try:
+        await asyncio.sleep(10)
+        await server_task
+    except asyncio.CancelledError:
+        pass
 
 
 async def wait_for_behaviour_is_killed(behaviour, tries=500, sleep=0.01):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -174,18 +174,15 @@ async def test_presence_subscribe():
                 self.presence.approve_subscription(jid)
 
             def on_subscribed(self, peer_jid):
-                self.presence.set_presence(PresenceType.AVAILABLE, PresenceShow.DND, "Working hard. Go away!", 0)
+                pass
 
             def on_presence_received(self, presence: Presence):
-                self.presence.set_presence(PresenceType.AVAILABLE, PresenceShow.DND, "Working hard. Go away!", 0)
-                self.agent.presence_trace.append(presence)
                 asyncio.create_task(self.agent.stop())
 
             async def run(self):
                 self.presence.on_subscribe = self.on_subscribe
                 self.presence.on_subscribed = self.on_subscribed
                 self.presence.on_presence_received = self.on_presence_received
-                self.presence.set_presence(PresenceType.AVAILABLE, PresenceShow.DND, "Working hard. Go away!", 0)
                 self.presence.subscribe(self.agent.jid2)
 
     class Agent2(Agent):
@@ -202,18 +199,15 @@ async def test_presence_subscribe():
                 self.presence.subscribe(jid)
 
             def on_subscribed(self, peer_jid):
-                self.presence.set_presence(PresenceType.AVAILABLE, PresenceShow.AWAY, "I'm taking a quick break", 5)
+                pass
 
             def on_presence_received(self, presence: Presence):
-
-                self.agent.presence_trace.append(presence)
                 asyncio.create_task(self.agent.stop())
 
             async def run(self):
                 self.presence.on_subscribe = self.on_subscribe
                 self.presence.on_subscribed = self.on_subscribed
                 self.presence.on_presence_received = self.on_presence_received
-                self.presence.set_presence(PresenceType.AVAILABLE, PresenceShow.AWAY, "I'm taking a quick break", 5)
 
     agent2 = Agent2(JID2, PWD)
     agent1 = Agent1(JID, PWD)
@@ -223,18 +217,16 @@ async def test_presence_subscribe():
     await agent2.start()
     await agent1.start()
     try:
-        await asyncio.wait_for(spade.wait_until_finished([agent1, agent2]), 10)
+        await asyncio.wait_for(spade.wait_until_finished([agent1, agent2]), 3)
     except asyncio.TimeoutError:
-        assert pytest.fail()
+        pass
 
     assert JID2 in agent1.presence.get_contacts()
     contact2: Contact = agent1.presence.get_contact(JID2)
     assert contact2.jid == JID2
     assert contact2.subscription == 'both'
-    assert contact2.current_presence.is_available()
 
     assert JID in agent2.presence.get_contacts()
     contact1: Contact = agent2.presence.get_contact(JID)
     assert contact1.jid == JID
     assert contact1.subscription == 'both'
-    assert contact1.current_presence.is_available()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,9 @@
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_connection(server):
+    loop = server
+    await asyncio.sleep(30)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,4 +1,5 @@
 import asyncio
+import os.path
 import sys
 from unittest.mock import patch
 
@@ -23,10 +24,7 @@ PWD = "1234"
 
 @pytest_asyncio.fixture(autouse=True)
 async def server():
-    loguru.logger.remove()
-    loguru.logger.add(sys.stdout, level="TRACE")
-
-    server = Server(Parameters(database_in_memory=True, database_purge=True))
+    server = Server(Parameters(database_in_memory=False, database_purge=True))
     task = asyncio.create_task(server.start())
     yield task
     task.cancel()
@@ -34,6 +32,9 @@ async def server():
         await task
     except asyncio.CancelledError:
         pass
+    finally:
+        if os.path.isfile('pyjabber.db'):
+            os.remove('pyjabber.db')
 
 
 @pytest.mark.asyncio

--- a/tests/test_presence_manager.py
+++ b/tests/test_presence_manager.py
@@ -97,12 +97,11 @@ async def test_handle_subscription_approve_all(jid):
     presence_subscribe["from"] = jid
     presence_subscribe["type"] = "subscribe"
     presence_subscribe["ask"] = "subscribe"
-    presence_subscribe["subscription"] = "subscribe"
 
     manager.handle_subscription(presence_subscribe)
 
     contact = manager.get_contact(jid.bare)
-    assert contact.subscription == "subscribed"
+    assert contact.subscription == "from"
 
 
 async def test_handle_subscription_manual(jid):
@@ -118,7 +117,7 @@ async def test_handle_subscription_manual(jid):
     manager.handle_subscription(presence_subscribe)
 
     contact = manager.get_contact(jid.bare)
-    assert contact.subscription == "subscribe"
+    assert contact.subscription == "none"
 
 
 async def test_set_presence():


### PR DESCRIPTION
Added e2e test for spade using the pyjabber server as a fixture.
Now the test can be launched without having a dedicated xmpp server running on the machine