### PR TITLE
Hotfix SPADE cli error + lint

### DIFF
--- a/spade/cli.py
+++ b/spade/cli.py
@@ -69,7 +69,8 @@ def create_cli():
             level=level,
         )
 
-        server = Server(Parameters(
+        server = Server(
+            Parameters(
                 host=host,
                 client_port=client_port,
                 server_port=server_port,

--- a/spade/cli.py
+++ b/spade/cli.py
@@ -4,6 +4,7 @@ import spade
 import socket
 
 from pyjabber.server import Server
+from pyjabber.server_parameters import Parameters
 from rich.console import Console
 from rich.panel import Panel
 from loguru import logger
@@ -68,14 +69,15 @@ def create_cli():
             level=level,
         )
 
-        server = Server(
-            host=host,
-            client_port=client_port,
-            server_port=server_port,
-            connection_timeout=timeout,
-            database_path=db,
-            database_purge=purge,
-            database_in_memory=memory,
+        server = Server(Parameters(
+                host=host,
+                client_port=client_port,
+                server_port=server_port,
+                connection_timeout=timeout,
+                database_path=db,
+                database_purge=purge,
+                database_in_memory=memory,
+            )
         )
 
         print_spade_info()

--- a/spade/message.py
+++ b/spade/message.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Dict, Union
+from typing import Optional, Dict, Union, Type
 
 from slixmpp import ClientXMPP
 from slixmpp.plugins.xep_0004.stanza.form import Form


### PR DESCRIPTION
Pyjabber now uses a wrapper for server parameters (host, port, timeout, etc.) that is missing in the SPADE cli launcher