### PR TITLE
Fix/setup Windows UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,15 @@ from setuptools import setup, find_packages
 
 def parse_requirements(filename):
     """load requirements from a pip requirements file"""
-    with open(filename) as f:
+    with open(filename, encoding='utf-8') as f:
         lineiter = [line.strip() for line in f]
     return [line for line in lineiter if line and not line.startswith("#")]
 
 
-with open("README.rst") as readme_file:
+with open("README.rst", encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-with open("HISTORY.rst") as history_file:
+with open("HISTORY.rst", encoding='utf-8') as history_file:
     history = history_file.read()
 
 requirements = parse_requirements("requirements.txt")


### PR DESCRIPTION
Fix for UnicodeDecodeError on Windows by adding `encoding='utf-8'` to file operations in setup.py

> Tested: `python setup.py develop` now works