### PR TITLE
Migrate docs to spadeagents.eu, both stable/develop versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,70 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: ["master", "develop"]
+    paths:
+      - "docs/**"
+      - "spade/**"
+      - "readthedocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches: ["master", "develop"]
+    paths:
+      - "docs/**"
+      - "spade/**"
+      - "readthedocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      DOCS_DESTINATION_DIR: ${{ github.ref == 'refs/heads/develop' && 'docs/spade/develop' || 'docs/spade' }}
+      SPADE_DOCS_CHANNEL: ${{ github.ref == 'refs/heads/develop' && 'develop' || 'stable' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.15"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Build Sphinx docs
+        run: |
+          rm -f docs/spade.rst docs/modules.rst
+          uv run sphinx-apidoc -o docs/ spade
+          uv run sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+          touch docs/_build/html/.nojekyll
+
+      - name: Deploy to gh-pages branch
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./docs/_build/html
+          destination_dir: ${{ env.DOCS_DESTINATION_DIR }}
+          keep_files: true
+          enable_jekyll: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,14 +26,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DOCS_DESTINATION_DIR: ${{ github.ref == 'refs/heads/develop' && 'develop' || 'stable' }}
+
 jobs:
-  build-and-deploy:
+  build-docs:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      DOCS_DESTINATION_DIR: ${{ github.ref == 'refs/heads/develop' && 'docs/spade/develop' || 'docs/spade' }}
-      SPADE_DOCS_CHANNEL: ${{ github.ref == 'refs/heads/develop' && 'develop' || 'stable' }}
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -47,19 +46,37 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.8.15"
+          enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --frozen
 
       - name: Build Sphinx docs
         run: |
-          rm -f docs/spade.rst docs/modules.rst
-          uv run sphinx-apidoc -o docs/ spade
-          uv run sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+          uv run --no-sync sphinx-apidoc -f -o docs/ spade
+          uv run --no-sync sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
           touch docs/_build/html/.nojekyll
 
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html
+
+  deploy-docs:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: build-docs
+    permissions:
+      contents: write
+    steps:
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html
+
       - name: Deploy to gh-pages branch
-        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,9 @@ Develop agents that can chat both with other agents and humans.
 🌐 **Official Website: https://spadeagents.eu** 🌐
 
 * Free software: MIT license
-* Documentation: http://spade-mas.readthedocs.io/
+* Documentation (latest): https://spadeagents.eu/docs/spade/
+* Documentation (develop): https://spadeagents.eu/docs/spade/develop/
+* Legacy docs (temporary): https://spade-mas.readthedocs.io/
 
 
 Features

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,38 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if show_develop_banner %}
+  <style>
+    .spade-dev-banner {
+      background: #f59e0b;
+      color: #111827;
+      text-align: center;
+      font-weight: 700;
+      padding: 8px 12px;
+      border-bottom: 1px solid #d97706;
+      width: 100%;
+    }
+    .spade-dev-banner a {
+      color: #111827;
+      text-decoration: underline;
+    }
+  </style>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var banner = document.createElement("div");
+      banner.className = "spade-dev-banner";
+      banner.innerHTML =
+        "You are viewing DEVELOPMENT docs. " +
+        "For stable docs, go to <a href=\"{{ stable_docs_url }}\">latest stable</a>.";
+      
+      var page = document.querySelector(".wy-nav-content");
+      if (page) {
+        page.parentNode.insertBefore(banner, page);
+      } else {
+        document.body.prepend(banner);
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,7 @@ html_theme = "sphinx_rtd_theme"
 # "default.css".
 html_static_path = ["_static"]
 
-docs_channel = os.environ.get("SPADE_DOCS_CHANNEL", "stable")
+docs_channel = os.environ.get("DOCS_DESTINATION_DIR", "stable")
 html_context = {
     "show_develop_banner": docs_channel == "develop",
     "stable_docs_url": "https://spadeagents.eu/docs/spade/",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "SPADE"
-copyright = "2020, Javi Palanca"
+copyright = "2026, Javi Palanca"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -146,6 +146,12 @@ html_theme = "sphinx_rtd_theme"
 # static files, so a file named "default.css" will overwrite the builtin
 # "default.css".
 html_static_path = ["_static"]
+
+docs_channel = os.environ.get("SPADE_DOCS_CHANNEL", "stable")
+html_context = {
+    "show_develop_banner": docs_channel == "develop",
+    "stable_docs_url": "https://spadeagents.eu/docs/spade/",
+}
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,7 +56,7 @@ This approach is useful for more complex MAS integrations and for obtaining a de
     │ URL:                                                                 │
     │   -  https://spadeagents.eu                                          │
     │ Documentation:                                                       │
-    │   -  http://spade-mas.readthedocs.io/                                │
+    │   -  https://spadeagents.eu/docs/spade/                              │
     ╰────────────────── Version: 4.1.2      License: MIT ──────────────────╯
     yyyy-m-d h:m:s | INFO     | pyjabber.server:run_server:89 - Starting server...
     yyyy-m-d h:m:s | INFO     | pyjabber.server:run_server:133 - Client domain => 0.0.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 [project.urls]
 Homepage = "https://spadeagents.eu"
 Repository = "https://github.com/javipalanca/spade"
-Documentation = "http://spade-mas.readthedocs.io/"
+Documentation = "https://spadeagents.eu/docs/spade/"
 
 [project.scripts]
 spade = "spade.cli:cli"

--- a/spade/cli.py
+++ b/spade/cli.py
@@ -100,7 +100,7 @@ def create_cli():
             "[green]URL:[/green]\n"
             "  - [cyan] https://spadeagents.eu[/cyan]\n"
             "[green]Documentation:[/green]\n"
-            "  - [cyan] http://spade-mas.readthedocs.io/[/cyan]"
+            "  - [cyan] https://spadeagents.eu/docs/spade/[/cyan]"
         )
 
         footer = f"[cyan]Version:[/cyan] {spade.__version__}   [magenta]License:[/magenta] MIT"


### PR DESCRIPTION
In SPADE repo, build docs with GH Actions on gh-pages branch, both stable and develop versions. Added a banner to identify develop version.

Decided to keep readthedocs page up for now...